### PR TITLE
treat nil as empty map in ?assoc

### DIFF
--- a/src/full/core/sugar.cljc
+++ b/src/full/core/sugar.cljc
@@ -34,7 +34,7 @@
   (->> (partition 2 kvs)
        (remove (comp nil? second))
        (map vec)
-       (into m)))
+       (into (or m {}))))
 
 (defn assoc-first
   "Replaces value of key `k` in map `m` with the first value  sequence

--- a/test/full/core/sugar_test.cljc
+++ b/test/full/core/sugar_test.cljc
@@ -13,7 +13,9 @@
   (is (= (?assoc {} :foo "bar") {:foo "bar"}))
   (is (= (?assoc {:foo "bar"} :foo "baz") {:foo "baz"}))
   (is (= (?assoc {:foo "bar"} :foo nil) {:foo "bar"}))
-  (is (= (?assoc {} :empty nil) {})))
+  (is (= (?assoc {} :empty nil) {}))
+  (is (= (?assoc nil :empty nil) {}))
+  (is (= (?assoc nil :foo "bar") {:foo "bar"})))
 
 (deftest test-index-by
   (is (= (index-by :id nil) {}))

--- a/test/full/core/sugar_test.cljc
+++ b/test/full/core/sugar_test.cljc
@@ -10,7 +10,6 @@
 
 (deftest test-?assoc
   (is (= (?assoc {} :foo "bar") {:foo "bar"}))
-  (is (= (?assoc {} :foo "bar") {:foo "bar"}))
   (is (= (?assoc {:foo "bar"} :foo "baz") {:foo "baz"}))
   (is (= (?assoc {:foo "bar"} :foo nil) {:foo "bar"}))
   (is (= (?assoc {} :empty nil) {}))


### PR DESCRIPTION
Treat nil as empty map in `?assoc` just like in `assoc`.