### PR TITLE
Since full.core specifies :aot all there are issues

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -5,6 +5,7 @@
             :url "http://www.eclipse.org/legal/epl-v10.html"
             :distribution :repo}
   :deploy-repositories [["releases" {:url "https://clojars.org/repo/" :creds :gpg}]]
+  :managed-dependencies [[org.clojure/tools.namespace "0.3.0"]]
   :dependencies [[org.clojure/clojure "1.10.1"]
                  [org.clojure/clojurescript "1.10.597"]
                  [org.clojure/tools.cli "0.3.5"]
@@ -16,7 +17,7 @@
                  [clj-yaml "0.4.0" :exclusions [org.yaml/snakeyaml]]
                  [org.yaml/snakeyaml "1.17"]
                  [clj-time "0.15.0"]
-                 [ns-tracker "0.3.1"]
+                 [ns-tracker "0.4.0"]
                  [commons-codec/commons-codec "1.10"]]
   :aliases {"at" ["test-refresh"]
             "ats" ["doo" "phantom"]}


### PR DESCRIPTION
This is because all of its libraries it depends on are packaged into the
jar that is published as a library. One of these libraries, ns-tracker
depends org.clojure/tools.namespace 0.2.11. Later versions of midje
are dependeny on or.clojure/tools.namespace 0.3.0. This causes issues
for libraries that try to include full.core and latest version of midje.

To fix this we force the version of tools.namespace to 0.3.0 using
managed dependencies section